### PR TITLE
Change .header-content paddings to fix unintentional horizontal scroll bar

### DIFF
--- a/_sass/initialize.scss
+++ b/_sass/initialize.scss
@@ -447,7 +447,7 @@ table {
 }
 
 .header-content {
-  padding: 10px;
+  padding-bottom: 10px;
   padding-top: 20px;
   width: 100%;
 }


### PR DESCRIPTION
Due to the value of padding in .header-content in initialize.scss, there is a horizontal scroll bar on the whole website as shown below which shouldn't be there:
![image](https://user-images.githubusercontent.com/60645387/169027047-5a6525e4-1e3b-42e4-8f30-2423ec7d47cf.png)
This PR fixes this issue by bounding the 10px padding only to the bottom, thereby removing left/right padding of header content.